### PR TITLE
Added prebid cache host to the k8s secrets file script

### DIFF
--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       restartPolicy: Always
       containers:
       - name: prebid-server
-        image: gcr.io/newscorp-newsiq/prebid-server:latest
+        image: gcr.io/newscorp-newsiq-dev/prebid-cloudops/prebid-server:latest
         env:
         - name: GUNICORN_CMD_ARGS
           value: --forwarded-allow-ips=*
@@ -44,11 +44,26 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.name
+        - name: PBS_CACHE_HOST
+          valueFrom:
+            secretKeyRef:
+              name: prebid-secrets
+              key: prebid_cache_host
+        - name: PBS_CACHE_PORT
+          valueFrom:
+            secretKeyRef:
+              name: prebid-secrets
+              key: prebid_cache_port
+        - name: PBS_CACHE_ENDPOINT
+          valueFrom:
+            secretKeyRef:
+              name: prebid-secrets
+              key: prebid_cache_endpoint
         - name: PBS_PROJECT_NAME
           valueFrom:
             secretKeyRef:
               name: prebid-secrets
-              key: project-name
+              key: project-name                    
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /secrets/config/prebid-service-account              
         volumeMounts:

--- a/kubernetes/update-k8s-secrets.sh
+++ b/kubernetes/update-k8s-secrets.sh
@@ -64,6 +64,9 @@ echo "Update prebid-secrets..."
 kubectl --namespace=prebid create secret generic prebid-secrets \
     --from-file=project-name=.secrets-repo-${ENV}/kubernetes/project_name \
     --from-file=prebid-service-account=.secrets-repo-${ENV}/kubernetes/prebid-server_service_account.json \
+    --from-file=prebid_cache_host=.secrets-repo-${ENV}/kubernetes/prebid_cache_host \
+    --from-file=prebid_cache_port=.secrets-repo-${ENV}/kubernetes/prebid_cache_port \
+    --from-file=prebid_cache_endpoint=.secrets-repo-${ENV}/kubernetes/prebid_cache_endpoint \
     --dry-run -o yaml | kubectl apply -f -    
 
 echo "Done."


### PR DESCRIPTION
This branch is created to add prebid-cache host to the update-k8-secrets script